### PR TITLE
Selecting table highlights annotation

### DIFF
--- a/src/core/mainwindow.cpp
+++ b/src/core/mainwindow.cpp
@@ -305,10 +305,6 @@ void MainWindow::handleTableClick(const QModelIndex &index) {
     // Get the row of the clicked item
     int row = index.row();
 
-    // Retrieve data from the model for the clicked row
-    QString className = model->data(model->index(row, 0)).toString();  // Assuming first column is "Class"
-    QString confidence = model->data(model->index(row, 1)).toString();  // Assuming second column is "Confidence"
-
     // Print the row data using qDebug()
     mainImage.selectedAnnotation = row;
     mainImage.triggerRepaint();

--- a/src/core/mainwindow.cpp
+++ b/src/core/mainwindow.cpp
@@ -72,6 +72,9 @@ MainWindow::MainWindow(std::shared_ptr<Project>& project, QWidget *parent)
         ui->modelConfSlider->setValue(project->settings.value("Model Confidence").toInt());
     });
 
+    // Connect the clicked signal of the data table to a custom slot
+    connect(ui->dataTable, &QTableView::clicked, this, &MainWindow::handleTableClick);
+
 
     // Connect image navigation buttons
     connect(ui->imgPrevBtn, &QPushButton::clicked, this, &MainWindow::navigatePrevious);
@@ -293,4 +296,21 @@ void MainWindow::addMedia(QStringList files) {
 void MainWindow::doneSlicing() {
     // This method could be called when video slicing is complete
     // It's currently empty, but could be used to update UI or perform other actions
+}
+
+void MainWindow::handleTableClick(const QModelIndex &index) {
+    // Check if the index is valid
+    if (!index.isValid()) return;
+
+    // Get the row of the clicked item
+    int row = index.row();
+
+    // Retrieve data from the model for the clicked row
+    QString className = model->data(model->index(row, 0)).toString();  // Assuming first column is "Class"
+    QString confidence = model->data(model->index(row, 1)).toString();  // Assuming second column is "Confidence"
+
+    // Print the row data using qDebug()
+    qDebug() << "Row clicked:" << row << ", Class:" << className << ", Confidence:" << confidence;
+    mainImage.selectedAnnotation = row;
+    mainImage.triggerRepaint();
 }

--- a/src/core/mainwindow.cpp
+++ b/src/core/mainwindow.cpp
@@ -310,7 +310,6 @@ void MainWindow::handleTableClick(const QModelIndex &index) {
     QString confidence = model->data(model->index(row, 1)).toString();  // Assuming second column is "Confidence"
 
     // Print the row data using qDebug()
-    qDebug() << "Row clicked:" << row << ", Class:" << className << ", Confidence:" << confidence;
     mainImage.selectedAnnotation = row;
     mainImage.triggerRepaint();
 }

--- a/src/core/mainwindow.h
+++ b/src/core/mainwindow.h
@@ -67,7 +67,10 @@ private:
     Ui::MainWindow *ui;
     // For Icons
     fa::QtAwesome* awesome;
-    
+
+    // Method for highlighting annotation when a row in the table is clicked
+    void handleTableClick(const QModelIndex &index);
+
     // Method for adding media files to the project
     void addMedia(QStringList files = {});
 

--- a/src/gui/annotatedimage.h
+++ b/src/gui/annotatedimage.h
@@ -47,10 +47,10 @@ class AnnotatedImage : public QWidget
     QRect target {};
     bool mouseWasPressed {false};
     std::shared_ptr<AnnotationHandle> selectedHandle {nullptr};
-    int selectedAnnotation {-1};
     QTransform worldToImageTransform {};
 
 public:
+    int selectedAnnotation {-1};
     QPushButton* annotationNewBtn;
     QComboBox* annotationClassCombo;
 
@@ -63,7 +63,6 @@ public:
         );
 
     void triggerRepaint();
-
 
 public slots:
     void resizeEvent(QResizeEvent* event) override;


### PR DESCRIPTION
## Overview
Implemented the ability to select annotations from the table. Thus, clicking on a table row will highlight the annotation on the main window preview.

### Key changes
1. MainWindow::handleTableClick()
a. This function handles the event created by clicking on the table row, sets the selectedAnnotation value, and triggers the repaint event
2. annotatedimage.h
a. selectedAnnotation variable moved to public